### PR TITLE
[BREAKING CHANGE] Allow slash in kv path

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,12 @@ spec:
   secretName: vault-secret-test
   secrets:
     - secretKey: username
-      path: secret/test
+      kvPath: secrets/kv
+      path: test
       field: username
     - secretKey: password
-      path: secret/test
+      kvPath: secrets/kv
+      path: test
       field: password
   config:
     addr: https://vault.example.com

--- a/deploy/crds/maupu_v1beta1_vaultsecret_cr.yaml
+++ b/deploy/crds/maupu_v1beta1_vaultsecret_cr.yaml
@@ -7,10 +7,12 @@ spec:
   secretName: vault-secret-test
   secrets:
     - secretKey: username
-      path: secret/test
+      kvPath: secrets/kv
+      path: test
       field: username
     - secretKey: password
-      path: secret/test
+      kvPath: secrets/kv
+      path: test
       field: password
   config:
     addr: https://vault.example.com

--- a/deploy/crds/maupu_v1beta1_vaultsecret_crd.yaml
+++ b/deploy/crds/maupu_v1beta1_vaultsecret_crd.yaml
@@ -70,6 +70,8 @@ spec:
                 properties:
                   field:
                     type: string
+                  kvPath:
+                    type: string
                   path:
                     type: string
                   secretKey:

--- a/pkg/apis/maupu/v1beta1/vaultsecret_types.go
+++ b/pkg/apis/maupu/v1beta1/vaultsecret_types.go
@@ -38,6 +38,8 @@ type VaultSecretSpecConfigAuth struct {
 type VaultSecretSpecSecret struct {
 	// Key name in the secret to create
 	SecretKey string `json:"secretKey,required"`
+	// Path of the key-value storage
+	KvPath string `json:"kvPath,required"`
 	// Path of the vault secret
 	Path string `json:"path,required"`
 	// Field to retrieve from the path

--- a/pkg/controller/vaultsecret/vaultsecret_controller.go
+++ b/pkg/controller/vaultsecret/vaultsecret_controller.go
@@ -214,7 +214,7 @@ func newSecretForCR(cr *maupuv1beta1.VaultSecret) (*corev1.Secret, error) {
 		status := true
 
 		// Vault read
-		sec, err := nmvault.Read(vclient, s.Path)
+		sec, err := nmvault.Read(vclient, s.KvPath, s.Path)
 
 		if err != nil {
 			hasError = true

--- a/pkg/vault/utils.go
+++ b/pkg/vault/utils.go
@@ -13,16 +13,11 @@ const (
 )
 
 // Read a path from vault taking account KV version 1 and 2 automatically
-func Read(vc *vapi.Client, p string) (map[string]interface{}, error) {
-	pathElts := strings.Split(p, "/")
-	kvPath := pathElts[0]
-	pathLessMount := ""
-	if len(pathElts) > 1 {
-		pathLessMount = path.Join(pathElts[1:]...)
-	}
+func Read(vc *vapi.Client, kvPath string, secretPath string) (map[string]interface{}, error) {
+	p := path.Join(kvPath, secretPath)
 
-	pathV1 := path.Join(kvPath, pathLessMount)
-	pathV2 := path.Join(kvPath, "data", pathLessMount)
+	pathV1 := path.Join(kvPath, secretPath)
+	pathV2 := path.Join(kvPath, "data", secretPath)
 
 	var data map[string]interface{}
 


### PR DESCRIPTION
instead of spliting path and use the first token as KV path, define a separate field for KV path which allows slash in the path