### PR TITLE
Add secret type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,31 @@ This secret would contain two keys filled with vault content:
 - `username`
 - `password`
 
+Here is another example for "dockerconfig" secrets:
+```
+apiVersion: maupu.org/v1beta1
+kind: VaultSecret
+metadata:
+  name: dockerconfig-example
+  namespace: nma
+spec:
+  secretName: dockerconfig-test
+  secretType: kubernetes.io/dockerconfigjson
+  secrets:
+    - secretKey: .dockerconfigjson
+      kvPath: secrets/dockerconfig
+      field: dockerconfigjson
+      path: /
+  config:
+    addr: https://vault.example.com
+    auth:
+      kubernetes:
+        role: myrole
+        cluster: kubernetes
+```
+
+It's possible to set the secret type in the spec with `secretType`, if it isn't specified the default value is `Opaque`.
+
 ## Vault configuration
 
 To authenticate, the operator uses the `config` section of the Custom Resource Definition. The following options are supported:

--- a/deploy/crds/maupu.org_vaultsecrets_crd.yaml
+++ b/deploy/crds/maupu.org_vaultsecrets_crd.yaml
@@ -76,6 +76,8 @@ spec:
               type: object
             secretName:
               type: string
+            secretType:
+              type: string
             secrets:
               items:
                 description: Define secrets to create from Vault

--- a/pkg/apis/maupu/v1beta1/vaultsecret_types.go
+++ b/pkg/apis/maupu/v1beta1/vaultsecret_types.go
@@ -1,6 +1,7 @@
 package v1beta1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -11,6 +12,7 @@ type VaultSecretSpec struct {
 	// +listType=set
 	Secrets    []VaultSecretSpecSecret `json:"secrets,required"`
 	SecretName string                  `json:"secretName,omitempty"`
+	SecretType corev1.SecretType       `json:"secretType,omitempty"`
 }
 
 // Configuration part of a vault-secret object

--- a/pkg/controller/vaultsecret/vaultsecret_controller.go
+++ b/pkg/controller/vaultsecret/vaultsecret_controller.go
@@ -188,6 +188,11 @@ func newSecretForCR(cr *maupuv1beta1.VaultSecret) (*corev1.Secret, error) {
 		secretName = cr.Name
 	}
 
+	secretType := cr.Spec.SecretType
+	if secretType == "" {
+		secretType = "Opaque"
+	}
+
 	// Authentication provider
 	authProvider, err := cr.GetVaultAuthProvider()
 	if err != nil {
@@ -260,5 +265,6 @@ func newSecretForCR(cr *maupuv1beta1.VaultSecret) (*corev1.Secret, error) {
 			Labels:    labels,
 		},
 		Data: secrets,
+		Type: secretType,
 	}, retErr
 }


### PR DESCRIPTION
# What
- Add `secretType` optional field to the `VaultSecretSpec`
- Update the README with an example