### PR TITLE
add `secretLabels` to add labels to generated secrets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ metadata:
   namespace: nma
 spec:
   secretName: vault-secret-test
+  secretLabels:
+    foo: bar
   secrets:
     - secretKey: username
       kvPath: secrets/kv
@@ -82,6 +84,8 @@ A corresponding secret would be created in the same namespace as the *VaultSecre
 This secret would contain two keys filled with vault content:
 - `username`
 - `password`
+
+It's possible to add labels to the generated secret with `secretLabels`.
 
 Here is another example for "dockerconfig" secrets:
 ```

--- a/deploy/crds/maupu.org_vaultsecrets_crd.yaml
+++ b/deploy/crds/maupu.org_vaultsecrets_crd.yaml
@@ -78,6 +78,10 @@ spec:
               type: string
             secretType:
               type: string
+            secretLabels:
+              additionalProperties:
+                type: string
+              type: object
             secrets:
               items:
                 description: Define secrets to create from Vault

--- a/pkg/apis/maupu/v1beta1/vaultsecret_types.go
+++ b/pkg/apis/maupu/v1beta1/vaultsecret_types.go
@@ -10,9 +10,10 @@ import (
 type VaultSecretSpec struct {
 	Config VaultSecretSpecConfig `json:"config,required"`
 	// +listType=set
-	Secrets    []VaultSecretSpecSecret `json:"secrets,required"`
-	SecretName string                  `json:"secretName,omitempty"`
-	SecretType corev1.SecretType       `json:"secretType,omitempty"`
+	Secrets      []VaultSecretSpecSecret `json:"secrets,required"`
+	SecretName   string                  `json:"secretName,omitempty"`
+	SecretType   corev1.SecretType       `json:"secretType,omitempty"`
+	SecretLabels map[string]string       `json:"secretLabels,omitempty"`
 }
 
 // Configuration part of a vault-secret object

--- a/pkg/controller/vaultsecret/vaultsecret_controller.go
+++ b/pkg/controller/vaultsecret/vaultsecret_controller.go
@@ -193,6 +193,10 @@ func newSecretForCR(cr *maupuv1beta1.VaultSecret) (*corev1.Secret, error) {
 		secretType = "Opaque"
 	}
 
+	for key, val := range cr.Spec.SecretLabels {
+		labels[key] = val
+	}
+
 	// Authentication provider
 	authProvider, err := cr.GetVaultAuthProvider()
 	if err != nil {


### PR DESCRIPTION
add `SecretLabels` to add labels to generated secrets.
One of the usecases is when creating secrets for ArgoCD
https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#clusters

They need `Secret` labeled with `argocd.argoproj.io/secret-type: cluster`.