### PR TITLE
Using client's service account to make a k8s auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 
 **Solution:** Use vault-secret custom resource to specify Vault server, path and keys and the operator will retrieve all the needed information from vault and push them into a Kubernetes secret resource ready to be used in the cluster.
 
+# Note on upgrading to 1.0.1 onward
+
+From version `1.0.1`, k8s auth method switches from using the local *service account* configured on the operator side to using the one from the client's namespace defined in the *custom resource*.
+This is improving security but as a result, you will probably have to check your vault configuration is in adequation with this change.
+
 # Installation
 
 ## Kubernetes version requirements

--- a/deploy/crds/maupu.org_vaultsecrets_crd.yaml
+++ b/deploy/crds/maupu.org_vaultsecrets_crd.yaml
@@ -59,6 +59,8 @@ spec:
                           type: string
                         role:
                           type: string
+                        serviceAccount:
+                          type: string
                       required:
                       - cluster
                       - role

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -15,6 +15,7 @@ rules:
   - events
   - configmaps
   - secrets
+  - serviceaccounts
   verbs:
   - '*'
 - apiGroups:

--- a/pkg/apis/maupu/v1beta1/utils.go
+++ b/pkg/apis/maupu/v1beta1/utils.go
@@ -3,11 +3,25 @@ package v1beta1
 import (
 	"errors"
 
+	"github.com/nmaupu/vault-secret/pkg/k8sutils"
 	nmvault "github.com/nmaupu/vault-secret/pkg/vault"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Get VaultAuthProvider implem from custom resource object
-func (cr *VaultSecret) GetVaultAuthProvider() (nmvault.VaultAuthProvider, error) {
+// BySecretKey allows sorting an array of VaultSecretSpecSecret by SecretKey
+type BySecretKey []VaultSecretSpecSecret
+
+// Len returns the len of a BySecretKey object
+func (a BySecretKey) Len() int { return len(a) }
+
+// Swap swaps two elements of a BySecretKey object
+func (a BySecretKey) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
+// Less checks if a given SecretKey object is lexicographically inferior to another SecretKey object
+func (a BySecretKey) Less(i, j int) bool { return a[i].SecretKey < a[j].SecretKey }
+
+// GetVaultAuthProvider implem from custom resource object
+func (cr *VaultSecret) GetVaultAuthProvider(c client.Client) (nmvault.VaultAuthProvider, error) {
 	// Checking order:
 	//   - Token
 	//   - AppRole
@@ -25,23 +39,23 @@ func (cr *VaultSecret) GetVaultAuthProvider() (nmvault.VaultAuthProvider, error)
 			cr.Spec.Config.Auth.AppRole.SecretID,
 		), nil
 	} else if cr.Spec.Config.Auth.Kubernetes.Role != "" {
+		// Retrieving token from the serviceAccount configured
+		saName := cr.Spec.Config.Auth.Kubernetes.ServiceAccount
+		if saName == "" {
+			saName = "default"
+		}
+
+		tok, err := k8sutils.GetTokenFromSA(c, cr.Namespace, saName)
+		if err != nil {
+			return nil, err
+		}
+
 		return nmvault.NewKubernetesProvider(
 			cr.Spec.Config.Auth.Kubernetes.Role,
 			cr.Spec.Config.Auth.Kubernetes.Cluster,
+			tok,
 		), nil
 	}
 
 	return nil, errors.New("Cannot find a way to authenticate, please choose between Token, AppRole or Kubernetes")
 }
-
-// BySecretKey allows sorting an array of VaultSecretSpecSecret by SecretKey
-type BySecretKey []VaultSecretSpecSecret
-
-// Len returns the len of a BySecretKey object
-func (a BySecretKey) Len() int { return len(a) }
-
-// Swap swaps two elements of a BySecretKey object
-func (a BySecretKey) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-
-// Less checks if a given SecretKey object is lexicographically inferior to another SecretKey object
-func (a BySecretKey) Less(i, j int) bool { return a[i].SecretKey < a[j].SecretKey }

--- a/pkg/apis/maupu/v1beta1/vaultsecret_types.go
+++ b/pkg/apis/maupu/v1beta1/vaultsecret_types.go
@@ -36,6 +36,8 @@ type VaultSecretSpecConfigAuth struct {
 type KubernetesAuthType struct {
 	Role    string `json:"role,required"`
 	Cluster string `json:"cluster,required"`
+	// ServiceAccount to use for authentication, using "default" if not provided
+	ServiceAccount string `json:"serviceAccount,omitempty"`
 }
 
 // AppRoleAuthType AppRole authentication type

--- a/pkg/k8sutils/resources.go
+++ b/pkg/k8sutils/resources.go
@@ -1,0 +1,40 @@
+package k8sutils
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetTokenFromSA gets the token associated to the first secret located in a k8s' service account
+func GetTokenFromSA(cli client.Client, ns, saName string) (string, error) {
+	if cli == nil {
+		return "", fmt.Errorf("Cannot get token from service account, k8s client is nil")
+	}
+
+	// Getting SA
+	saClient := &corev1.ServiceAccount{}
+	err := cli.Get(context.TODO(), types.NamespacedName{Name: saName, Namespace: ns}, saClient)
+	if err != nil && errors.IsNotFound(err) {
+		return "", fmt.Errorf("Unable to retrieve service account, err=%v", err)
+	}
+
+	if len(saClient.Secrets) == 0 {
+		return "", fmt.Errorf("No secret associated with the service account %s/%s", ns, saName)
+	}
+
+	// TODO See how to handle this slice of Secrets instead of taking the first one
+	saSecret := saClient.Secrets[0]
+	secret := &corev1.Secret{}
+	err = cli.Get(context.TODO(), types.NamespacedName{Name: saSecret.Name, Namespace: ns}, secret)
+	if err != nil {
+		return "", fmt.Errorf("Unable to retrieve the secret from the service account, err=%v", err)
+	}
+
+	// Finally, set the token
+	return string(secret.Data["token"]), nil
+}


### PR DESCRIPTION
Better security using the client's service account to authenticate with the k8s method.
Vault Operator needs to be able to get serviceaccounts and secrets of the target namespace.