### PR TITLE
Add secretAnnotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ spec:
   secretName: vault-secret-test
   secretLabels:
     foo: bar
+  secretAnnotations:
+    foo: bar
   secrets:
     - secretKey: username
       kvPath: secrets/kv
@@ -93,7 +95,7 @@ This secret would contain two keys filled with vault content:
 
 ---
 
-It's possible to add labels to the generated secret with `secretLabels`.
+It's possible to add annotations and labels to the generated secret with `secretAnnotations` and `secretLabels`.
 
 Here is another example for "dockerconfig" secrets:
 ```

--- a/deploy/crds/maupu.org_vaultsecrets_crd.yaml
+++ b/deploy/crds/maupu.org_vaultsecrets_crd.yaml
@@ -80,6 +80,10 @@ spec:
               additionalProperties:
                 type: string
               type: object
+            secretAnnotations:
+              additionalProperties:
+                type: string
+              type: object
             secretName:
               type: string
             secretType:

--- a/pkg/apis/maupu/v1beta1/vaultsecret_types.go
+++ b/pkg/apis/maupu/v1beta1/vaultsecret_types.go
@@ -14,6 +14,7 @@ type VaultSecretSpec struct {
 	SecretName   string                  `json:"secretName,omitempty"`
 	SecretType   corev1.SecretType       `json:"secretType,omitempty"`
 	SecretLabels map[string]string       `json:"secretLabels,omitempty"`
+	SecretAnnotations map[string]string  `json:"secretAnnotations,omitempty"`
 	SyncPeriod   metav1.Duration         `json:"syncPeriod,omitempty"`
 }
 

--- a/pkg/controller/vaultsecret/vaultsecret_controller.go
+++ b/pkg/controller/vaultsecret/vaultsecret_controller.go
@@ -373,9 +373,9 @@ func (r *ReconcileVaultSecret) newSecretForCR(cr *maupuv1beta1.VaultSecret) (*co
 	}
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: cr.Namespace,
-			Labels:    labels,
+			Name:        secretName,
+			Namespace:   cr.Namespace,
+			Labels:      labels,
 			Annotations: cr.Spec.SecretAnnotations,
 		},
 		Data: secrets,

--- a/pkg/controller/vaultsecret/vaultsecret_controller.go
+++ b/pkg/controller/vaultsecret/vaultsecret_controller.go
@@ -279,6 +279,11 @@ func (r *ReconcileVaultSecret) newSecretForCR(cr *maupuv1beta1.VaultSecret) (*co
 		labels[key] = val
 	}
 
+	annotations := map[string]string{}
+	for key, val := range cr.Spec.SecretAnnotations {
+		annotations[key] = val
+	}
+
 	// Authentication provider
 	authProvider, err := cr.GetVaultAuthProvider(r.client)
 	if err != nil {
@@ -376,6 +381,7 @@ func (r *ReconcileVaultSecret) newSecretForCR(cr *maupuv1beta1.VaultSecret) (*co
 			Name:      secretName,
 			Namespace: cr.Namespace,
 			Labels:    labels,
+			Annotations: annotations,
 		},
 		Data: secrets,
 		Type: secretType,

--- a/pkg/controller/vaultsecret/vaultsecret_controller.go
+++ b/pkg/controller/vaultsecret/vaultsecret_controller.go
@@ -279,11 +279,6 @@ func (r *ReconcileVaultSecret) newSecretForCR(cr *maupuv1beta1.VaultSecret) (*co
 		labels[key] = val
 	}
 
-	annotations := map[string]string{}
-	for key, val := range cr.Spec.SecretAnnotations {
-		annotations[key] = val
-	}
-
 	// Authentication provider
 	authProvider, err := cr.GetVaultAuthProvider(r.client)
 	if err != nil {
@@ -381,7 +376,7 @@ func (r *ReconcileVaultSecret) newSecretForCR(cr *maupuv1beta1.VaultSecret) (*co
 			Name:      secretName,
 			Namespace: cr.Namespace,
 			Labels:    labels,
-			Annotations: annotations,
+			Annotations: cr.Spec.SecretAnnotations,
 		},
 		Data: secrets,
 		Type: secretType,


### PR DESCRIPTION
Add secretAnnotation which adds annotations to the generated secrets.
Tekton uses k8s' secret annotations to authenticate to git, Docker, etc. [docs](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#understanding-credential-selection)