### PR TITLE
Update CRD apiVersion to v1

### DIFF
--- a/config/crd/bases/maupu.org_vaultsecrets.yaml
+++ b/config/crd/bases/maupu.org_vaultsecrets.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,174 +15,173 @@ spec:
     plural: vaultsecrets
     singular: vaultsecret
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: VaultSecret is the Schema for the vaultsecrets API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VaultSecretSpec defines the desired state of VaultSecret
-          properties:
-            config:
-              description: VaultSecretSpecConfig Configuration part of a vault-secret
-                object
-              properties:
-                addr:
-                  type: string
-                auth:
-                  description: VaultSecretSpecConfigAuth Mean of authentication for
-                    Vault
-                  properties:
-                    approle:
-                      description: AppRoleAuthType AppRole authentication type
-                      properties:
-                        name:
-                          type: string
-                        roleId:
-                          type: string
-                        secretId:
-                          type: string
-                      required:
-                      - roleId
-                      - secretId
-                      type: object
-                    kubernetes:
-                      description: KubernetesAuthType Kubernetes authentication type
-                      properties:
-                        cluster:
-                          type: string
-                        role:
-                          type: string
-                        serviceAccount:
-                          description: ServiceAccount to use for authentication, using
-                            "default" if not provided
-                          type: string
-                      required:
-                      - cluster
-                      - role
-                      type: object
-                    token:
-                      type: string
-                  type: object
-                insecure:
-                  type: boolean
-                namespace:
-                  type: string
-              required:
-              - addr
-              - auth
-              type: object
-            secretAnnotations:
-              additionalProperties:
-                type: string
-              type: object
-            secretLabels:
-              additionalProperties:
-                type: string
-              type: object
-            secretName:
-              type: string
-            secretType:
-              type: string
-            secrets:
-              items:
-                description: VaultSecretSpecSecret Defines secrets to create from
-                  Vault
-                properties:
-                  field:
-                    description: Field to retrieve from the path
-                    type: string
-                  kvPath:
-                    description: Path of the key-value storage
-                    type: string
-                  kvVersion:
-                    description: KvVersion is the version of the KV backend, if unspecified,
-                      try to automatically determine it
-                    type: integer
-                  path:
-                    description: Path of the vault secret
-                    type: string
-                  secretKey:
-                    description: Key name in the secret to create
-                    type: string
-                required:
-                - field
-                - kvPath
-                - path
-                - secretKey
-                type: object
-              type: array
-            syncPeriod:
-              type: string
-          required:
-          - config
-          - secrets
-          type: object
-        status:
-          description: VaultSecretStatus Status field regarding last custom resource
-            process
-          properties:
-            entries:
-              items:
-                description: VaultSecretStatusEntry Entry for the status field
-                properties:
-                  message:
-                    type: string
-                  rootError:
-                    type: string
-                  secret:
-                    description: VaultSecretSpecSecret Defines secrets to create from
-                      Vault
-                    properties:
-                      field:
-                        description: Field to retrieve from the path
-                        type: string
-                      kvPath:
-                        description: Path of the key-value storage
-                        type: string
-                      kvVersion:
-                        description: KvVersion is the version of the KV backend, if
-                          unspecified, try to automatically determine it
-                        type: integer
-                      path:
-                        description: Path of the vault secret
-                        type: string
-                      secretKey:
-                        description: Key name in the secret to create
-                        type: string
-                    required:
-                    - field
-                    - kvPath
-                    - path
-                    - secretKey
-                    type: object
-                  status:
-                    type: boolean
-                required:
-                - secret
-                - status
-                type: object
-              type: array
-          type: object
-      type: object
-  version: v1beta1
   versions:
   - name: v1beta1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        description: VaultSecret is the Schema for the vaultsecrets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VaultSecretSpec defines the desired state of VaultSecret
+            properties:
+              config:
+                description: VaultSecretSpecConfig Configuration part of a vault-secret
+                  object
+                properties:
+                  addr:
+                    type: string
+                  auth:
+                    description: VaultSecretSpecConfigAuth Mean of authentication for
+                      Vault
+                    properties:
+                      approle:
+                        description: AppRoleAuthType AppRole authentication type
+                        properties:
+                          name:
+                            type: string
+                          roleId:
+                            type: string
+                          secretId:
+                            type: string
+                        required:
+                        - roleId
+                        - secretId
+                        type: object
+                      kubernetes:
+                        description: KubernetesAuthType Kubernetes authentication type
+                        properties:
+                          cluster:
+                            type: string
+                          role:
+                            type: string
+                          serviceAccount:
+                            description: ServiceAccount to use for authentication, using
+                              "default" if not provided
+                            type: string
+                        required:
+                        - cluster
+                        - role
+                        type: object
+                      token:
+                        type: string
+                    type: object
+                  insecure:
+                    type: boolean
+                  namespace:
+                    type: string
+                required:
+                - addr
+                - auth
+                type: object
+              secretAnnotations:
+                additionalProperties:
+                  type: string
+                type: object
+              secretLabels:
+                additionalProperties:
+                  type: string
+                type: object
+              secretName:
+                type: string
+              secretType:
+                type: string
+              secrets:
+                items:
+                  description: VaultSecretSpecSecret Defines secrets to create from
+                    Vault
+                  properties:
+                    field:
+                      description: Field to retrieve from the path
+                      type: string
+                    kvPath:
+                      description: Path of the key-value storage
+                      type: string
+                    kvVersion:
+                      description: KvVersion is the version of the KV backend, if unspecified,
+                        try to automatically determine it
+                      type: integer
+                    path:
+                      description: Path of the vault secret
+                      type: string
+                    secretKey:
+                      description: Key name in the secret to create
+                      type: string
+                  required:
+                  - field
+                  - kvPath
+                  - path
+                  - secretKey
+                  type: object
+                type: array
+              syncPeriod:
+                type: string
+            required:
+            - config
+            - secrets
+            type: object
+          status:
+            description: VaultSecretStatus Status field regarding last custom resource
+              process
+            properties:
+              entries:
+                items:
+                  description: VaultSecretStatusEntry Entry for the status field
+                  properties:
+                    message:
+                      type: string
+                    rootError:
+                      type: string
+                    secret:
+                      description: VaultSecretSpecSecret Defines secrets to create from
+                        Vault
+                      properties:
+                        field:
+                          description: Field to retrieve from the path
+                          type: string
+                        kvPath:
+                          description: Path of the key-value storage
+                          type: string
+                        kvVersion:
+                          description: KvVersion is the version of the KV backend, if
+                            unspecified, try to automatically determine it
+                          type: integer
+                        path:
+                          description: Path of the vault secret
+                          type: string
+                        secretKey:
+                          description: Key name in the secret to create
+                          type: string
+                      required:
+                      - field
+                      - kvPath
+                      - path
+                      - secretKey
+                      type: object
+                    status:
+                      type: boolean
+                  required:
+                  - secret
+                  - status
+                  type: object
+                type: array
+            type: object
+        type: object
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/kustomizeconfig.yaml
+++ b/config/crd/kustomizeconfig.yaml
@@ -5,12 +5,12 @@ nameReference:
   fieldSpecs:
   - kind: CustomResourceDefinition
     group: apiextensions.k8s.io
-    path: spec/conversion/webhookClientConfig/service/name
+    path: spec/conversion/webhook/clientConfig/service/name
 
 namespace:
 - kind: CustomResourceDefinition
   group: apiextensions.k8s.io
-  path: spec/conversion/webhookClientConfig/service/namespace
+  path: spec/conversion/webhook/clientConfig/service/namespace
   create: false
 
 varReference:

--- a/config/crd/patches/cainjection_in_vaultsecrets.yaml
+++ b/config/crd/patches/cainjection_in_vaultsecrets.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/webhook_in_vaultsecrets.yaml
+++ b/config/crd/patches/webhook_in_vaultsecrets.yaml
@@ -1,17 +1,18 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: vaultsecrets.maupu.org
 spec:
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert


### PR DESCRIPTION
Update the CRD to `apiVersion: apiextensions.k8s.io/v1`

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122

Fixes #32 