### PR TITLE
Fix CRD

### DIFF
--- a/config/crd/bases/maupu.org_vaultsecrets.yaml
+++ b/config/crd/bases/maupu.org_vaultsecrets.yaml
@@ -126,7 +126,7 @@ spec:
                   - secretKey
                   type: object
                 type: array
-                x-kubernetes-list-type: set
+                x-kubernetes-list-type: atomic
               syncPeriod:
                 type: string
             required:
@@ -178,7 +178,7 @@ spec:
                   - status
                   type: object
                 type: array
-                x-kubernetes-list-type: set
+                x-kubernetes-list-type: atomic
             type: object
         type: object
     served: true


### PR DESCRIPTION
Update CRD resolving 

`The CustomResourceDefinition "vaultsecrets.maupu.org" is invalid: 
* spec.validation.openAPIV3Schema.properties[spec].properties[secrets].items.x-kubernetes-map-type: Invalid value: "null": must be atomic as item of a list with x-kubernetes-list-type=set
* spec.validation.openAPIV3Schema.properties[status].properties[entries].items.x-kubernetes-map-type: Invalid value: "null": must be atomic as item of a list with x-kubernetes-list-type=set`

Fixes #34 

