### PR TITLE
Using projected volume mount to read SA token

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,6 @@
 From version `1.0.1`, k8s auth method switches from using the local *service account* configured on the operator side to using the one from the client's namespace defined in the *custom resource*.
 This is improving security but as a result, you will probably have to check your vault configuration is in adequation with this change.
 
-# Note for Kubernetes 1.24+
-
-From Kubernetes 1.24, secrets are not created along a service account anymore. A secret needs to be manually created to make the controller happy.
-See https://github.com/nmaupu/vault-secret/issues/40 for more info.
-
 # Installation
 
 ## Kubernetes version requirements

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ If several configuration options are specified, there are used in the following 
 
 - Operator SDK installation (https://github.com/operator-framework/operator-sdk)
 - Go Dep (https://golang.github.io/dep/docs/installation.html)
+- Kubebuilder (https://github.com/kubernetes-sigs/kubebuilder)
 
 ## Building
 

--- a/api/v1beta1/utils.go
+++ b/api/v1beta1/utils.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/nmaupu/vault-secret/pkg/k8sutils"
 	nmvault "github.com/nmaupu/vault-secret/pkg/vault"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // BySecretKey allows sorting an array of VaultSecretSpecSecret by SecretKey
@@ -37,7 +36,7 @@ func (a BySecretKey) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a BySecretKey) Less(i, j int) bool { return a[i].SecretKey < a[j].SecretKey }
 
 // GetVaultAuthProvider implem from custom resource object
-func (cr *VaultSecret) GetVaultAuthProvider(c client.Client) (nmvault.AuthProvider, error) {
+func (cr *VaultSecret) GetVaultAuthProvider() (nmvault.AuthProvider, error) {
 	// Checking order:
 	//   - Token
 	//   - AppRole
@@ -55,13 +54,8 @@ func (cr *VaultSecret) GetVaultAuthProvider(c client.Client) (nmvault.AuthProvid
 			cr.Spec.Config.Auth.AppRole.SecretID,
 		), nil
 	} else if cr.Spec.Config.Auth.Kubernetes.Role != "" {
-		// Retrieving token from the serviceAccount configured
-		saName := cr.Spec.Config.Auth.Kubernetes.ServiceAccount
-		if saName == "" {
-			saName = "default"
-		}
 
-		tok, err := k8sutils.GetTokenFromSA(c, cr.Namespace, saName)
+		tok, err := k8sutils.GetTokenFromSA()
 		if err != nil {
 			return nil, err
 		}

--- a/controllers/vaultsecret_controller.go
+++ b/controllers/vaultsecret_controller.go
@@ -258,7 +258,7 @@ func (r *VaultSecretReconciler) readSecretData(cr *maupuv1beta1.VaultSecret) (ma
 	reqLogger := log.WithValues("func", "readSecretData")
 
 	// Authentication provider
-	authProvider, err := cr.GetVaultAuthProvider(r.Client)
+	authProvider, err := cr.GetVaultAuthProvider()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/k8sutils/resources.go
+++ b/pkg/k8sutils/resources.go
@@ -17,40 +17,15 @@ limitations under the License.
 package k8sutils
 
 import (
-	"context"
 	"fmt"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"io/ioutil"
 )
 
-// GetTokenFromSA gets the token associated to the first secret located in a k8s' service account
-func GetTokenFromSA(cli client.Client, ns, saName string) (string, error) {
-	if cli == nil {
-		return "", fmt.Errorf("Cannot get token from service account, k8s client is nil")
-	}
-
-	// Getting SA
-	saClient := &corev1.ServiceAccount{}
-	err := cli.Get(context.TODO(), types.NamespacedName{Name: saName, Namespace: ns}, saClient)
-	if err != nil && errors.IsNotFound(err) {
+// GetTokenFromSA gets the SA token the projected volume mount
+func GetTokenFromSA() (string, error) {
+	token, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	if err != nil {
 		return "", fmt.Errorf("Unable to retrieve service account, err=%v", err)
 	}
-
-	if len(saClient.Secrets) == 0 {
-		return "", fmt.Errorf("No secret associated with the service account %s/%s", ns, saName)
-	}
-
-	// TODO See how to handle this slice of Secrets instead of taking the first one
-	saSecret := saClient.Secrets[0]
-	secret := &corev1.Secret{}
-	err = cli.Get(context.TODO(), types.NamespacedName{Name: saSecret.Name, Namespace: ns}, secret)
-	if err != nil {
-		return "", fmt.Errorf("Unable to retrieve the secret from the service account, err=%v", err)
-	}
-
-	// Finally, set the token
-	return string(secret.Data["token"]), nil
+	return string(token), nil
 }


### PR DESCRIPTION
This PR fixes #40 without the need to create `kubernetes.io/service-account-token` secrets and link them to SA's.
The projected volume mounts also work with earlier versions of Kubernetes.

A new image was built with `docker build . -t xxxxxxx/vault-secret:0.0.1-fix02` and tested with k8s 1.24 and 1.23